### PR TITLE
Remove unnecessary markers params.

### DIFF
--- a/GoogleStaticMap.js
+++ b/GoogleStaticMap.js
@@ -152,7 +152,7 @@ class GoogleStaticMap extends Component {
       hasCenterMarker
       } = this.props;
 
-    const markerParams = `markers=icon:dot%7Cshadow:true%7C${latitude},${longitude}`;
+    const markerParams = `markers=${latitude},${longitude}`;
     return hasCenterMarker ? markerParams : '';
   }
 


### PR DESCRIPTION
1. I got static map error from bellow link.
[https://maps.googleapis.com/maps/api/staticmap?center=35.642546,139.687433&zoom=16&scale=2&size=375x200&maptype=roadmap&format=jpg&markers=icon:dot%7Cshadow:true%7C35.642546,139.687433](https://maps.googleapis.com/maps/api/staticmap?center=35.642546,139.687433&zoom=16&scale=2&size=375x200&maptype=roadmap&format=jpg&markers=icon:dot%7Cshadow:true%7C35.642546,139.687433)

2. It looks good after remove `icon` param.
[https://maps.googleapis.com/maps/api/staticmap?center=35.642546,139.687433&zoom=16&scale=2&size=375x200&maptype=roadmap&format=jpg&markers=shadow:true%7C35.642546,139.687433](https://maps.googleapis.com/maps/api/staticmap?center=35.642546,139.687433&zoom=16&scale=2&size=375x200&maptype=roadmap&format=jpg&markers=shadow:true%7C35.642546,139.687433)

3. And it couldn't find `shadow` param on below link.
[https://developers.google.com/maps/documentation/static-maps/intro#Markers](https://developers.google.com/maps/documentation/static-maps/intro#Markers)
