### PR TITLE
Fix for deprecated PropTypes

### DIFF
--- a/GoogleStaticMap.js
+++ b/GoogleStaticMap.js
@@ -1,5 +1,6 @@
 import {Image, PixelRatio} from 'react-native';
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 const defaultMapScale = ()=> {
   const isRetina = PixelRatio.get() >= 2;
@@ -72,13 +73,13 @@ class GoogleStaticMap extends Component {
   static propTypes = {
     ...imagePropTypes,
 
-    latitude: React.PropTypes.string.isRequired,
+    latitude: PropTypes.string.isRequired,
 
-    longitude: React.PropTypes.string.isRequired,
+    longitude: PropTypes.string.isRequired,
 
-    size: React.PropTypes.shape({
-      width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired
+    size: PropTypes.shape({
+      width: PropTypes.number.isRequired,
+      height: PropTypes.number.isRequired
     }),
 
     /**
@@ -87,31 +88,31 @@ class GoogleStaticMap extends Component {
      *
      * @see https://developers.google.com/maps/documentation/staticmaps/intro#Zoomlevels
      */
-    zoom: React.PropTypes.number.isRequired,
+    zoom: PropTypes.number.isRequired,
 
     /**
      * scale affects the number of pixels that are returned.
      * scale=2 returns twice as many pixels as scale=1 while retaining the same coverage area and level of detail
      * The default value is calculated from the screen PixelRatio.
      */
-    scale: React.PropTypes.number,
+    scale: PropTypes.number,
 
     /**
      * @see https://developers.google.com/maps/documentation/staticmaps/intro#ImageFormats
      */
-    format: React.PropTypes.oneOf(IMAGE_FORMATS_VALUES),
+    format: PropTypes.oneOf(IMAGE_FORMATS_VALUES),
 
     /**
      * @see https://developers.google.com/maps/documentation/staticmaps/intro#MapTypes
      */
-    mapType: React.PropTypes.oneOf(MAP_TYPES_VALUES),
+    mapType: PropTypes.oneOf(MAP_TYPES_VALUES),
 
     /**
      * Add a marker on the center
      */
-    hasCenterMarker: React.PropTypes.bool,
+    hasCenterMarker: PropTypes.bool,
 
-    key: React.PropTypes.string.isRequired,
+    key: PropTypes.string.isRequired,
   };
 
   static defaultProps = {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "author": "Adam Farhi <yelled3@gmail.com> (https://github.com/yelled3)",
   "peerDependencies": {
-    "react-native": ">=0.6.0"
+    "react-native": ">=0.6.0",
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Importing PropTypes from the "react" module was deprecated in react 15.5. This fixes that.