### PR TITLE
Change url apiKey parameter to key

### DIFF
--- a/GoogleStaticMap.js
+++ b/GoogleStaticMap.js
@@ -164,7 +164,7 @@ class GoogleStaticMap extends Component {
   get apiKeyParam() {
     const apiKey = this.props.apiKey;
 
-    return apiKey ? `apiKey=${apiKey}` : '';
+    return apiKey ? `key=${apiKey}` : '';
   }
 }
 


### PR DESCRIPTION
the new google maps api does not recognise apiKey parameter in the url but instead key parameter must be used